### PR TITLE
Add 'allowDangerousElements' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ And then rebuild the DOM Node from that JSON using [`.toDOM()`](#domJSON.toDOM):
 
 ```javascript
 var DOMDocumentFragment = domJSON.toDOM(jsonOutput);
-someDOMElement.parentNode.replaceChild(DOMDocumentFragment, someDOMElement);
+someDOMElement.parentNode.replaceChild(someDOMElement, DOMDocumentFragment);
 ```
 When creating the JSON object, there are many precise options available, ensuring that developers can produce very specific and compact outputs.  For example, the following will produce a JSON copy of `someDOMElement`'s DOM tree that is only two levels deep, contains no "offset*," "client*," or "scroll*" type DOM properties, only keeps the "id" attribute on each DOM Node, and outputs a string (rather than a JSON-friendly object):
 
@@ -187,57 +187,97 @@ The result:
 	"tagName": "DIV"
 }
 ```
-## API
+## Objects
+
+<dl>
+<dt><a href="#domJSON">domJSON</a> : <code>object</code></dt>
+<dd><p>domJSON is a global variable to store two methods: <code>.toJSON()</code> to convert a DOM Node into a JSON object, and <code>.toDOM()</code> to turn that JSON object back into a DOM Node</p>
+</dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#FilterList">FilterList</a> : <code>Object</code> | <code>Array</code></dt>
+<dd><p>An object specifying a list of fields and how to filter it, or an array with the first value being an optional boolean to convey the same information</p>
+</dd>
+</dl>
+
+<a name="domJSON"></a>
+
+## domJSON : <code>object</code>
 domJSON is a global variable to store two methods: `.toJSON()` to convert a DOM Node into a JSON object, and `.toDOM()` to turn that JSON object back into a DOM Node
 
+**Kind**: global namespace  
 
-* [domJSON](#domJSON)
-  * [.toJSON(node, [opts])](#domJSON.toJSON) ⇒ <code>Object</code> \| <code>string</code>
-  * [.toDOM(obj, [opts])](#domJSON.toDOM) ⇒ <code>DocumentFragment</code>
+* [domJSON](#domJSON) : <code>object</code>
+    * [.toJSON(node, [opts])](#domJSON.toJSON) ⇒ <code>Object</code> &#124; <code>string</code>
+    * [.toDOM(obj, [opts])](#domJSON.toDOM) ⇒ <code>DocumentFragment</code>
 
 <a name="domJSON.toJSON"></a>
 
+
 * * *
-#### domJSON.toJSON(node, [opts]) ⇒ <code>Object</code> \| <code>string</code>
+#### domJSON.toJSON(node, [opts]) ⇒ <code>Object</code> &#124; <code>string</code>
 Take a DOM node and convert it to simple object literal (or JSON string) with no circular references and no functions or events
 
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| node | <code>Node</code> | The actual DOM Node which will be the starting point for parsing the DOM Tree |
-| \[opts\] | <code>Object</code> | A list of all method options |
-| \[opts.absolutePaths=`'action', 'data', 'href', 'src'`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Only relevant if `opts.attributes` is not `false`; use `true` to convert all relative paths found in attribute values to absolute paths, or specify a `FilterList` of keys to boolean search |
-| \[opts.attributes=`true`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Use `true` to copy all attribute key-value pairs, or specify a `FilterList` of keys to boolean search |
-| \[opts.computedStyle=`false`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Use `true` to parse the results of "window.getComputedStyle()" on every node (specify a `FilterList` of CSS properties to be included via boolean search); this operation is VERY costly performance-wise! |
-| \[opts.cull=`false`\] | <code>boolean</code> | Use `true` to ignore empty element properties |
-| \[opts.deep=`true`\] | <code>boolean</code> \| <code>number</code> | Use `true` to iterate and copy all childNodes, or an INTEGER indicating how many levels down the DOM tree to iterate |
-| \[opts.domProperties=true\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | 'false' means only 'tagName', 'nodeType', and 'nodeValue' properties will be copied, while a `FilterList` can specify DOM properties to include or exclude in the output (except for ones which serialize the DOM Node, which are handled separately by `opts.serialProperties`) |
-| \[opts.htmlOnly=`false`\] | <code>boolean</code> | Use `true` to only iterate through childNodes where nodeType = 1 (aka, instances of HTMLElement); irrelevant if `opts.deep` is `true` |
-| \[opts.metadata=`false`\] | <code>boolean</code> | Output a special object of the domJSON class, which includes metadata about this operation |
-| \[opts.serialProperties=`true`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Use `true` to ignore the properties that store a serialized version of this DOM Node (ex: outerHTML, innerText, etc), or specify a `FilterList` of serial properties (no boolean search!) |
-| \[opts.stringify=`false`\] | <code>boolean</code> | Output a JSON string, or just a JSON-ready javascript object? |
-
-**Returns**: <code>Object</code> \| <code>string</code> - A JSON-friendly object, or JSON string, of the DOM node -> JSON conversion output  
+**Kind**: static method of <code>[domJSON](#domJSON)</code>  
+**Returns**: <code>Object</code> &#124; <code>string</code> - A JSON-friendly object, or JSON string, of the DOM node -> JSON conversion output  
 **Todo**
 
-- {boolean|FilterList} [opts.parse=`false`] a `FilterList` of properties that are DOM nodes, but will still be copied **PLANNED**
+- [ ] {boolean|FilterList} [opts.parse=`false`] a `FilterList` of properties that are DOM nodes, but will still be copied **PLANNED**
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| node | <code>Node</code> |  | The actual DOM Node which will be the starting point for parsing the DOM Tree |
+| [opts] | <code>Object</code> |  | A list of all method options |
+| [opts.allowDangerousElements] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to parse the potentially dangerous elements `<link>` and `<script>` |
+| [opts.absolutePaths] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;&#x27;action&#x27;, &#x27;data&#x27;, &#x27;href&#x27;, &#x27;src&#x27;&#x60;</code> | Only relevant if `opts.attributes` is not `false`; use `true` to convert all relative paths found in attribute values to absolute paths, or specify a `FilterList` of keys to boolean search |
+| [opts.attributes] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;true&#x60;</code> | Use `true` to copy all attribute key-value pairs, or specify a `FilterList` of keys to boolean search |
+| [opts.computedStyle] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;false&#x60;</code> | Use `true` to parse the results of "window.getComputedStyle()" on every node (specify a `FilterList` of CSS properties to be included via boolean search); this operation is VERY costly performance-wise! |
+| [opts.cull] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to ignore empty element properties |
+| [opts.deep] | <code>boolean</code> &#124; <code>number</code> | <code>&#x60;true&#x60;</code> | Use `true` to iterate and copy all childNodes, or an INTEGER indicating how many levels down the DOM tree to iterate |
+| [opts.domProperties] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>true</code> | 'false' means only 'tagName', 'nodeType', and 'nodeValue' properties will be copied, while a `FilterList` can specify DOM properties to include or exclude in the output (except for ones which serialize the DOM Node, which are handled separately by `opts.serialProperties`) |
+| [opts.htmlOnly] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to only iterate through childNodes where nodeType = 1 (aka, instances of HTMLElement); irrelevant if `opts.deep` is `true` |
+| [opts.metadata] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Output a special object of the domJSON class, which includes metadata about this operation |
+| [opts.serialProperties] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;true&#x60;</code> | Use `true` to ignore the properties that store a serialized version of this DOM Node (ex: outerHTML, innerText, etc), or specify a `FilterList` of serial properties (no boolean search!) |
+| [opts.stringify] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Output a JSON string, or just a JSON-ready javascript object? |
 
 <a name="domJSON.toDOM"></a>
+
 
 * * *
 #### domJSON.toDOM(obj, [opts]) ⇒ <code>DocumentFragment</code>
 Take the JSON-friendly object created by the `.toJSON()` method and rebuild it back into a DOM Node
 
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| obj | <code>Object</code> | A JSON friendly object, or even JSON string, of some DOM Node |
-| \[opts\] | <code>Object</code> | A list of all method options |
-| \[opts.noMeta=`false`\] | <code>boolean</code> | `true` means that this object is not wrapped in metadata, which it makes it somewhat more difficult to rebuild properly... |
-
+**Kind**: static method of <code>[domJSON](#domJSON)</code>  
 **Returns**: <code>DocumentFragment</code> - A `DocumentFragment` (nodeType 11) containing the result of unpacking the input `obj`  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| obj | <code>Object</code> |  | A JSON friendly object, or even JSON string, of some DOM Node |
+| [opts] | <code>Object</code> |  | A list of all method options |
+| [opts.allowDangerousElements] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to include the potentially dangerous elements `<link>` and `<script>` |
+| [opts.noMeta] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | `true` means that this object is not wrapped in metadata, which it makes it somewhat more difficult to rebuild properly... |
+
+<a name="FilterList"></a>
+
+## FilterList : <code>Object</code> &#124; <code>Array</code>
+An object specifying a list of fields and how to filter it, or an array with the first value being an optional boolean to convey the same information
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| exclude | <code>boolean</code> | <code>false</code> | If this is set to `true`, the `filter` property will specify which fields to exclude from the result (boolean difference), not which ones to include (boolean intersection) |
+| values | <code>Array.&lt;string&gt;</code> |  | An array of strings which specify the fields to include/exclude from some broader list |
+
 
 
 ## Performance
-A major goal of this library is performance.  That being said, there is one way to _significantly_ slow it down: setting `opts.computedStyle` to `true`.  This forces the browser to run [`window.getComputedStyle()`](https://developer.mozilla.org/en-US/docs/Web/API/Window.getComputedStyle) on every node in the DOM Tree, which is [really, really slow](http://jsperf.com/getcomputedstyle-vs-style-vs-css/2), since it requires a redraw _each time it does it!_  Obviously, there are situations where you need the computed style and this performance hit is unavoidable, but otherwise, keep `opts.computedStyle` set to `false`.  Besides that, I'm working on writing some benchmark tests to give developers an idea of how each option affects the speed of domJSON, but this will take some time!
+A major goal of this library is performance.  That being said, there is one way to _significantly_ slow it down: setting `opts.computedStyle` to `true`.  This forces the browser to run [`window.getComputedStyle()`](https://developer.mozilla.org/en-US/docs/Web/API/Window.getComputedStyle) on every node in the DOM Tree, which is [really, really slow](http://jsperf.com/getcomputedstyle-vs-style-vs-css/2), since it requires a redraw _each time it does it!_  Obviously, there are situations where this you need the computed style and this performance hit is unavoidable, but otherwise, keep `opts.computedStyle` set to `false`.  Besides that, I'm working on writing some benchmark tests to give developers an idea of how each option affects the speed of domJSON, but this will take some time!
 
 Generally speaking, avoid using `FilterList` type options for best performance.  The optimal settings in terms of speed, without sacrificing any information, are as follows:
 ```javascript
@@ -280,7 +320,7 @@ If you make changes that you feel need to be documented in the readme, please up
 ```
 gulp docs
 ```
-## License
+##License
 
 The MIT License (MIT)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,47 +1,87 @@
-##API
+## Objects
+
+<dl>
+<dt><a href="#domJSON">domJSON</a> : <code>object</code></dt>
+<dd><p>domJSON is a global variable to store two methods: <code>.toJSON()</code> to convert a DOM Node into a JSON object, and <code>.toDOM()</code> to turn that JSON object back into a DOM Node</p>
+</dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#FilterList">FilterList</a> : <code>Object</code> | <code>Array</code></dt>
+<dd><p>An object specifying a list of fields and how to filter it, or an array with the first value being an optional boolean to convey the same information</p>
+</dd>
+</dl>
+
+<a name="domJSON"></a>
+
+## domJSON : <code>object</code>
 domJSON is a global variable to store two methods: `.toJSON()` to convert a DOM Node into a JSON object, and `.toDOM()` to turn that JSON object back into a DOM Node
 
+**Kind**: global namespace  
 
-* [domJSON](#domJSON)
-  * [.toJSON(node, [opts])](#domJSON.toJSON) ⇒ <code>Object</code> \| <code>string</code>
-  * [.toDOM(obj, [opts])](#domJSON.toDOM) ⇒ <code>DocumentFragment</code>
+* [domJSON](#domJSON) : <code>object</code>
+    * [.toJSON(node, [opts])](#domJSON.toJSON) ⇒ <code>Object</code> &#124; <code>string</code>
+    * [.toDOM(obj, [opts])](#domJSON.toDOM) ⇒ <code>DocumentFragment</code>
 
 <a name="domJSON.toJSON"></a>
 
+
 * * *
-####domJSON.toJSON(node, [opts]) ⇒ <code>Object</code> \| <code>string</code>
+#### domJSON.toJSON(node, [opts]) ⇒ <code>Object</code> &#124; <code>string</code>
 Take a DOM node and convert it to simple object literal (or JSON string) with no circular references and no functions or events
 
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| node | <code>Node</code> | The actual DOM Node which will be the starting point for parsing the DOM Tree |
-| \[opts\] | <code>Object</code> | A list of all method options |
-| \[opts.absolutePaths=`'action', 'data', 'href', 'src'`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Only relevant if `opts.attributes` is not `false`; use `true` to convert all relative paths found in attribute values to absolute paths, or specify a `FilterList` of keys to boolean search |
-| \[opts.attributes=`true`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Use `true` to copy all attribute key-value pairs, or specify a `FilterList` of keys to boolean search |
-| \[opts.computedStyle=`false`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Use `true` to parse the results of "window.getComputedStyle()" on every node (specify a `FilterList` of CSS properties to be included via boolean search); this operation is VERY costly performance-wise! |
-| \[opts.cull=`false`\] | <code>boolean</code> | Use `true` to ignore empty element properties |
-| \[opts.deep=`true`\] | <code>boolean</code> \| <code>number</code> | Use `true` to iterate and copy all childNodes, or an INTEGER indicating how many levels down the DOM tree to iterate |
-| \[opts.domProperties=true\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | 'false' means only 'tagName', 'nodeType', and 'nodeValue' properties will be copied, while a `FilterList` can specify DOM properties to include or exclude in the output (except for ones which serialize the DOM Node, which are handled separately by `opts.serialProperties`) |
-| \[opts.htmlOnly=`false`\] | <code>boolean</code> | Use `true` to only iterate through childNodes where nodeType = 1 (aka, instances of HTMLElement); irrelevant if `opts.deep` is `true` |
-| \[opts.metadata=`false`\] | <code>boolean</code> | Output a special object of the domJSON class, which includes metadata about this operation |
-| \[opts.serialProperties=`true`\] | <code>boolean</code> \| <code>[FilterList](#FilterList)</code> | Use `true` to ignore the properties that store a serialized version of this DOM Node (ex: outerHTML, innerText, etc), or specify a `FilterList` of serial properties (no boolean search!) |
-| \[opts.stringify=`false`\] | <code>boolean</code> | Output a JSON string, or just a JSON-ready javascript object? |
-
-**Returns**: <code>Object</code> \| <code>string</code> - A JSON-friendly object, or JSON string, of the DOM node -> JSON conversion output  
+**Kind**: static method of <code>[domJSON](#domJSON)</code>  
+**Returns**: <code>Object</code> &#124; <code>string</code> - A JSON-friendly object, or JSON string, of the DOM node -> JSON conversion output  
 **Todo**
 
-- {boolean|FilterList} [opts.parse=`false`] a `FilterList` of properties that are DOM nodes, but will still be copied **PLANNED**
+- [ ] {boolean|FilterList} [opts.parse=`false`] a `FilterList` of properties that are DOM nodes, but will still be copied **PLANNED**
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| node | <code>Node</code> |  | The actual DOM Node which will be the starting point for parsing the DOM Tree |
+| [opts] | <code>Object</code> |  | A list of all method options |
+| [opts.allowDangerousElements] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to parse the potentially dangerous elements `<link>` and `<script>` |
+| [opts.absolutePaths] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;&#x27;action&#x27;, &#x27;data&#x27;, &#x27;href&#x27;, &#x27;src&#x27;&#x60;</code> | Only relevant if `opts.attributes` is not `false`; use `true` to convert all relative paths found in attribute values to absolute paths, or specify a `FilterList` of keys to boolean search |
+| [opts.attributes] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;true&#x60;</code> | Use `true` to copy all attribute key-value pairs, or specify a `FilterList` of keys to boolean search |
+| [opts.computedStyle] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;false&#x60;</code> | Use `true` to parse the results of "window.getComputedStyle()" on every node (specify a `FilterList` of CSS properties to be included via boolean search); this operation is VERY costly performance-wise! |
+| [opts.cull] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to ignore empty element properties |
+| [opts.deep] | <code>boolean</code> &#124; <code>number</code> | <code>&#x60;true&#x60;</code> | Use `true` to iterate and copy all childNodes, or an INTEGER indicating how many levels down the DOM tree to iterate |
+| [opts.domProperties] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>true</code> | 'false' means only 'tagName', 'nodeType', and 'nodeValue' properties will be copied, while a `FilterList` can specify DOM properties to include or exclude in the output (except for ones which serialize the DOM Node, which are handled separately by `opts.serialProperties`) |
+| [opts.htmlOnly] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to only iterate through childNodes where nodeType = 1 (aka, instances of HTMLElement); irrelevant if `opts.deep` is `true` |
+| [opts.metadata] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Output a special object of the domJSON class, which includes metadata about this operation |
+| [opts.serialProperties] | <code>boolean</code> &#124; <code>[FilterList](#FilterList)</code> | <code>&#x60;true&#x60;</code> | Use `true` to ignore the properties that store a serialized version of this DOM Node (ex: outerHTML, innerText, etc), or specify a `FilterList` of serial properties (no boolean search!) |
+| [opts.stringify] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Output a JSON string, or just a JSON-ready javascript object? |
 
 <a name="domJSON.toDOM"></a>
 
+
 * * *
-####domJSON.toDOM(obj, [opts]) ⇒ <code>DocumentFragment</code>
+#### domJSON.toDOM(obj, [opts]) ⇒ <code>DocumentFragment</code>
 Take the JSON-friendly object created by the `.toJSON()` method and rebuild it back into a DOM Node
 
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-| obj | <code>Object</code> | A JSON friendly object, or even JSON string, of some DOM Node |
-| \[opts\] | <code>Object</code> | A list of all method options |
-| \[opts.noMeta=`false`\] | <code>boolean</code> | `true` means that this object is not wrapped in metadata, which it makes it somewhat more difficult to rebuild properly... |
-
+**Kind**: static method of <code>[domJSON](#domJSON)</code>  
 **Returns**: <code>DocumentFragment</code> - A `DocumentFragment` (nodeType 11) containing the result of unpacking the input `obj`  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| obj | <code>Object</code> |  | A JSON friendly object, or even JSON string, of some DOM Node |
+| [opts] | <code>Object</code> |  | A list of all method options |
+| [opts.allowDangerousElements] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | Use `true` to include the potentially dangerous elements `<link>` and `<script>` |
+| [opts.noMeta] | <code>boolean</code> | <code>&#x60;false&#x60;</code> | `true` means that this object is not wrapped in metadata, which it makes it somewhat more difficult to rebuild properly... |
+
+<a name="FilterList"></a>
+
+## FilterList : <code>Object</code> &#124; <code>Array</code>
+An object specifying a list of fields and how to filter it, or an array with the first value being an optional boolean to convey the same information
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| exclude | <code>boolean</code> | <code>false</code> | If this is set to `true`, the `filter` property will specify which fields to exclude from the result (boolean difference), not which ones to include (boolean intersection) |
+| values | <code>Array.&lt;string&gt;</code> |  | An array of strings which specify the fields to include/exclude from some broader list |
+

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-debug": "~2.0.0",
     "gulp-foreach": "0.1.0",
     "gulp-if": "~1.2.5",
-    "gulp-jsdoc-to-markdown": "~0.1.6",
+    "gulp-jsdoc-to-markdown": "^1.2.2",
     "gulp-karma": "0.0.4",
     "gulp-open": "~0.3.1",
     "gulp-regex-replace": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-util": "^3.0.1",
     "http-server": "^0.7.4",
     "jasmine-core": "2.0.4",
-    "karma": "~0.12.28",
+    "karma": "~0.13.22",
     "karma-chrome-launcher": "~0.1.7",
     "karma-coverage": "~0.2.7",
     "karma-firefox-launcher": "^0.1.4",

--- a/src/domJSON.js
+++ b/src/domJSON.js
@@ -560,6 +560,7 @@
 	 * Take a DOM node and convert it to simple object literal (or JSON string) with no circular references and no functions or events
 	 * @param {Node} node The actual DOM Node which will be the starting point for parsing the DOM Tree
 	 * @param {Object} [opts] A list of all method options
+	 * @param {boolean} [opts.allowDangerousElements=`false`] Use `true` to parse the potentially dangerous elements `<link>` and `<script>`
 	 * @param {boolean|FilterList} [opts.absolutePaths=`'action', 'data', 'href', 'src'`] Only relevant if `opts.attributes` is not `false`; use `true` to convert all relative paths found in attribute values to absolute paths, or specify a `FilterList` of keys to boolean search
 	 * @param {boolean|FilterList} [opts.attributes=`true`] Use `true` to copy all attribute key-value pairs, or specify a `FilterList` of keys to boolean search
 	 * @param {boolean|FilterList} [opts.computedStyle=`false`] Use `true` to parse the results of "window.getComputedStyle()" on every node (specify a `FilterList` of CSS properties to be included via boolean search); this operation is VERY costly performance-wise!
@@ -773,6 +774,7 @@
 	 * Take the JSON-friendly object created by the `.toJSON()` method and rebuild it back into a DOM Node
 	 * @param {Object} obj A JSON friendly object, or even JSON string, of some DOM Node
 	 * @param {Object} [opts] A list of all method options
+	 * @param {boolean} [opts.allowDangerousElements=`false`] Use `true` to include the potentially dangerous elements `<link>` and `<script>`
 	 * @param {boolean} [opts.noMeta=`false`] `true` means that this object is not wrapped in metadata, which it makes it somewhat more difficult to rebuild properly...
 	 * @return {DocumentFragment} A `DocumentFragment` (nodeType 11) containing the result of unpacking the input `obj`
 	 * @method

--- a/test/results/spec/chrome.html
+++ b/test/results/spec/chrome.html
@@ -9,18 +9,18 @@
     <h1>Unit Test Results</h1>
     <table cellspacing="0" cellpadding="0" border="0">
       <tr class="overview">
-        <td colspan="3" title="Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36">Browser: Chrome 39.0.2171 (Windows 7)</td>
+        <td colspan="3" title="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36">Browser: Chrome 68.0.3440 (Mac OS X 10.12.6)</td>
       </tr>
       <tr class="overview">
-        <td colspan="3">Timestamp: 2015-01-09T11:28:08</td>
+        <td colspan="3">Timestamp: 2018-08-16T16:02:27</td>
       </tr>
       <tr>
         <td colspan="3">
-          70 tests / 
+          73 tests / 
           0 errors / 
           0 failures / 
           0 skipped / 
-          runtime: 0.521s
+          runtime: 0.605s
         </td>
       </tr>
       <tr class="header">
@@ -29,17 +29,17 @@
         <td>Suite / Results</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.005s</td>
+        <td>Passed in 0.007s</td>
         <td>should return a boolean if provided one</td>
         <td>domJSON &raquo; private utility APIs &raquo; FilterList custom type processing</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0s</td>
         <td>should return true if provided a truthy value that isn&apos;t an object</td>
         <td>domJSON &raquo; private utility APIs &raquo; FilterList custom type processing</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0s</td>
         <td>should return false if provided falsey value, or an invalid object (no &quot;values&quot; property)</td>
         <td>domJSON &raquo; private utility APIs &raquo; FilterList custom type processing</td>
       </tr>
@@ -49,7 +49,7 @@
         <td>domJSON &raquo; private utility APIs &raquo; FilterList custom type processing</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0.001s</td>
         <td>should return a shorthand array if provided a shorthand array</td>
         <td>domJSON &raquo; private utility APIs &raquo; FilterList custom type processing</td>
       </tr>
@@ -74,17 +74,17 @@
         <td>domJSON &raquo; private utility APIs &raquo; object extension</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0.001s</td>
         <td>should extend an empty object with multiple supplied objects, without altering the originals</td>
         <td>domJSON &raquo; private utility APIs &raquo; object extension</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.001s</td>
+        <td>Passed in 0s</td>
         <td>should return only the unique values from a single input array</td>
         <td>domJSON &raquo; private utility APIs &raquo; unique array union</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0s</td>
+        <td>Passed in 0.001s</td>
         <td>should combine several arrays with distinct values</td>
         <td>domJSON &raquo; private utility APIs &raquo; unique array union</td>
       </tr>
@@ -94,32 +94,32 @@
         <td>domJSON &raquo; private utility APIs &raquo; unique array union</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.001s</td>
+        <td>Passed in 0s</td>
         <td>should combine several arrays with non-distinct values, both internally and relative to each other</td>
         <td>domJSON &raquo; private utility APIs &raquo; unique array union</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0.001s</td>
         <td>should copy only the first level of an array</td>
         <td>domJSON &raquo; private utility APIs &raquo; shallow copying</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.001s</td>
+        <td>Passed in 0s</td>
         <td>should copy only the first level of an object</td>
         <td>domJSON &raquo; private utility APIs &raquo; shallow copying</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.003s</td>
+        <td>Passed in 0.001s</td>
         <td>should, if provided an array, return a new array containing only the values that match a second filter array</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean intersection</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.001s</td>
+        <td>Passed in 0s</td>
         <td>should, if provided an object, return a new object keeping only the properties that match a provided filter array</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean intersection</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.001s</td>
+        <td>Passed in 0s</td>
         <td>should, if provided an array, return only the values that match are absent from a second filter array</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean difference</td>
       </tr>
@@ -129,17 +129,17 @@
         <td>domJSON &raquo; private utility APIs &raquo; boolean difference</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0s</td>
         <td>should return a shallow copy of the provided object/array if a filter property is not specified</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean filtering</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.002s</td>
+        <td>Passed in 0.001s</td>
         <td>should return a shallow copy of the provided object/array if a filter property is boolean true</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean filtering</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0s</td>
+        <td>Passed in 0.001s</td>
         <td>should return an empty object/array if the filter property is boolean false</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean filtering</td>
       </tr>
@@ -154,57 +154,62 @@
         <td>domJSON &raquo; private utility APIs &raquo; boolean filtering</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.001s</td>
+        <td>Passed in 0.003s</td>
         <td>should do an intersection if the leading boolean is omitted from the provided filtering array</td>
         <td>domJSON &raquo; private utility APIs &raquo; boolean filtering</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.026s</td>
+        <td>Passed in 0.025s</td>
         <td>should work with the default settings</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about basic output control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.023s</td>
-        <td>should always ignore &quot;link&quot; and &quot;script&quot; tags</td>
+        <td>Passed in 0.054s</td>
+        <td>should ignore &quot;link&quot; and &quot;script&quot; tags per default</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about basic output control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.017s</td>
+        <td>should not ignore &quot;link&quot; and &quot;script&quot; tags with `allowDangerousElements: true` option</td>
+        <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about basic output control</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 0.007s</td>
         <td>should be able to not cull falsey DOM properties (excepting 0 and boolean false) from the output object</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about basic output control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.01s</td>
+        <td>Passed in 0.011s</td>
         <td>should be able to produce a stringified JSON output</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about basic output control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.011s</td>
         <td>should be able to produce an output of just the JSONified DOM node, excluding all metadata</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about basic output control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.015s</td>
         <td>should note the version number domJSON when the operation was performed</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about metadata output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.005s</td>
         <td>should sotre the options used to generate this JSON object</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about metadata output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.007s</td>
         <td>should note the UTC time when the operation was performed</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about metadata output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.006s</td>
         <td>should note how long it took to perform the operation</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about metadata output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.005s</td>
         <td>should note the domain of the browser when the operation was performed</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about metadata output</td>
       </tr>
@@ -219,12 +224,12 @@
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about metadata output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.003s</td>
+        <td>Passed in 0.004s</td>
         <td>should be able to ignore child nodes if requested (aka, no recursion)</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about recursion depth control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.007s</td>
         <td>should be able to recurse through the entire depth of the DOM tree</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about recursion depth control</td>
       </tr>
@@ -234,57 +239,57 @@
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about recursion depth control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.006s</td>
+        <td>Passed in 0.011s</td>
         <td>should be able only recurse through only HTML Elements (nodeType = 1)</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about recursion depth control</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.02s</td>
+        <td>Passed in 0.031s</td>
         <td>should not perform custom filtering if passed a non-array value that isn&apos;t false, or not specified</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.01s</td>
+        <td>Passed in 0.017s</td>
         <td>should only copy required properties (nodeType, nodeValue, tagName) when custom filtering flag is set to false</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.011s</td>
+        <td>Passed in 0.008s</td>
         <td>should be able to output only the specified DOM properties if provided an array of strings</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.009s</td>
         <td>should be able to output all DOM properties except for those specified if provided an array of strings with a leading boolean true</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.005s</td>
         <td>should always exclude the following DOM properties from the output, even if they are included in a filter array: children, classList, dataset</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.01s</td>
+        <td>Passed in 0.006s</td>
         <td>should always include the following DOM properties in the output, even if they are excluded by a filter array: nodeType, nodeValue, tagName</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.013s</td>
+        <td>Passed in 0.01s</td>
         <td>should never include DOM properties that reference other DOM Nodes (nextSibling, parentElement, etc), in order to prevent infinite recursion loops</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.005s</td>
         <td>should be able to ignore all serialized DOM properties (like outerHTML, textContent, prefix, etc), overriding other property filters</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.007s</td>
         <td>should be able to include all serialized DOM properties, overriding other property filters</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.006s</td>
         <td>should be able to include a specific set of serialized DOM properties, overriding other property filters</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
@@ -294,67 +299,67 @@
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about filtering which DOM properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.008s</td>
+        <td>Passed in 0.006s</td>
         <td>should be able to ignore all HTML attributes</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which attributes to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.013s</td>
         <td>should be able to include all HTML attributes</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which attributes to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.01s</td>
+        <td>Passed in 0.012s</td>
         <td>should be able to include a set of HTML attributes, as specified by an array</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which attributes to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.012s</td>
+        <td>Passed in 0.007s</td>
         <td>should be able to exclude a set of HTML attributes, as specified by an array</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which attributes to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.009s</td>
+        <td>Passed in 0.006s</td>
         <td>should be able to ignore computed styles</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which computed style properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.027s</td>
+        <td>Passed in 0.031s</td>
         <td>should be able to include all computed styles</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which computed style properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.024s</td>
+        <td>Passed in 0.028s</td>
         <td>should be able to include a set of computed style properties on the given nodes, as specified by an array</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which computed style properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.029s</td>
+        <td>Passed in 0.058s</td>
         <td>should be able to exclude a set of computed style properties on the given nodes, as specified by an array</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about enumerating which computed style properties to include in the output</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.017s</td>
+        <td>Passed in 0.025s</td>
         <td>should be able to ignore all relative paths contained in DOM attributes, and keep them as is</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about converting relative paths in attributes</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.015s</td>
+        <td>Passed in 0.014s</td>
         <td>should be able to convert all relative paths contained in DOM attributes to absolute paths, while leaving absolute URLs and dataURIs untouched</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about converting relative paths in attributes</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.013s</td>
+        <td>Passed in 0.014s</td>
         <td>should be able to convert all relative paths contained in a specified list of DOM attributes to absolute paths, while leaving absolute URLs and dataURIs untouched</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about converting relative paths in attributes</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.017s</td>
+        <td>Passed in 0.016s</td>
         <td>should be able to convert all relative paths contained in DOM attributes, except those contained on a specified list, to absolute paths, while leaving absolute URLs and dataURIs untouched</td>
         <td>domJSON &raquo; JSON object creation [.toJSON() method] &raquo; for various options &raquo; about converting relative paths in attributes</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.004s</td>
+        <td>Passed in 0.007s</td>
         <td>should output a document fragment</td>
         <td>domJSON &raquo; DOM node creation [.toDOM() method]</td>
       </tr>
@@ -364,7 +369,7 @@
         <td>domJSON &raquo; DOM node creation [.toDOM() method]</td>
       </tr>
       <tr class="pass">
-        <td>Passed in 0.003s</td>
+        <td>Passed in 0.002s</td>
         <td>should be able to process a JSON friendly object, with metadata</td>
         <td>domJSON &raquo; DOM node creation [.toDOM() method]</td>
       </tr>
@@ -376,6 +381,16 @@
       <tr class="pass">
         <td>Passed in 0.003s</td>
         <td>should be able to process a JSON friendly object, without metadata</td>
+        <td>domJSON &raquo; DOM node creation [.toDOM() method]</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 0.001s</td>
+        <td>should skip &quot;link&quot; and &quot;script&quot; tags per default</td>
+        <td>domJSON &raquo; DOM node creation [.toDOM() method]</td>
+      </tr>
+      <tr class="pass">
+        <td>Passed in 0.004s</td>
+        <td>should not skip &quot;link&quot; and &quot;script&quot; tags with `allowDangerousElements: true` option</td>
         <td>domJSON &raquo; DOM node creation [.toDOM() method]</td>
       </tr>
     </table>

--- a/test/spec/domJSON.js
+++ b/test/spec/domJSON.js
@@ -401,10 +401,23 @@
 						var alpha = document.querySelector('.alpha').appendChild(samplePI);
 					}
 
+					//Append a link tag to the alpha node
+					var sampleLink = document.createElement('link');
+					sampleLink.href = 'style.css';
+					sampleLink.rel = 'stylesheet';
+					document.querySelector('.alpha').appendChild(sampleLink);
+
+					//Append a script tag to the alpha node
+					var sampleScript = document.createElement('script');
+					sampleScript.type = 'text/javascript';
+					sampleScript.textContent = '// nothing here';
+					document.querySelector('.alpha').appendChild(sampleScript);
+
 					//Save a stringified version
 					if (!stringifiedTest) {
 						stringifiedTest = domJSON.toJSON(containerNode, {
-							stringify: true
+							stringify: true,
+							allowDangerousElements: true
 						});
 					}
 				});
@@ -427,7 +440,7 @@
 						expect(result.node.childNodes[0].childNodes[0].childNodes[0].childNodes[0].childNodes[0].nodeType).toBe(3);
 					});
 
-					it('should always ignore "link" and "script" tags', function(){
+					it('should ignore "link" and "script" tags per default', function(){
 						var fails = 0;
 						domJSON.toJSON($('head').get(0)).node.childNodes.forEach(function(v,i){
 							if (v.tagName === 'SCRIPT' || v.tagName === 'LINK') {
@@ -441,6 +454,17 @@
 						});
 						
 						expect(fails).toBe(0);
+					});
+
+					it('should not ignore "link" and "script" tags with `allowDangerousElements: true` option', function(){
+						var count = 0;
+						domJSON.toJSON($('body').get(0), { allowDangerousElements: true }).node.childNodes.forEach(function(v){
+							if (v.tagName === 'SCRIPT' || v.tagName === 'LINK') {
+								count++;
+							}
+						});
+
+						expect(count).toBeGreaterThan(0);
 					});
 
 					it('should be able to not cull falsey DOM properties (excepting 0 and boolean false) from the output object', function(){
@@ -980,7 +1004,7 @@
 		describe('DOM node creation [.toDOM() method]', function(){
 			beforeEach(function(){
 				if (!stringifiedTest) {
-					stringifiedTest = '{"meta":{"domain":"http://localhost:5050/","userAgent":"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36","version":"0.1.0","options":{"absolutePaths":["action","data","href","src"],"attributes":true,"computedStyle":false,"cull":true,"deep":true,"filter":false,"htmlOnly":false,"metadata":true,"serialProperties":false,"stringify":true,"domProperties":[true,"attributes","childNodes","children","classList","dataset","style","innerHTML","innerText","outerHTML","outerText","prefix","text","textContent","wholeText"],"absoluteBase":"http://localhost:5050/"},"clock":6},"node":{"spellcheck":true,"isContentEditable":false,"contentEditable":"inherit","hidden":false,"draggable":false,"tabIndex":-1,"translate":true,"childElementCount":1,"className":"container otherClass","scrollHeight":184,"scrollWidth":71,"scrollTop":0,"scrollLeft":0,"clientHeight":184,"clientWidth":72,"clientTop":0,"clientLeft":0,"offsetHeight":184,"offsetWidth":72,"offsetTop":10,"offsetLeft":1511,"localName":"div","namespaceURI":"http://www.w3.org/1999/xhtml","tagName":"DIV","baseURI":"http://localhost:5050/?","nodeType":1,"nodeName":"DIV","attributes":{"class":"container otherClass"},"childNodes":[{"spellcheck":true,"isContentEditable":false,"contentEditable":"inherit","hidden":false,"draggable":false,"tabIndex":-1,"translate":true,"childElementCount":1,"className":"alpha","scrollHeight":178,"scrollWidth":65,"scrollTop":0,"scrollLeft":0,"clientHeight":178,"clientWidth":66,"clientTop":3,"clientLeft":3,"offsetHeight":184,"offsetWidth":72,"offsetTop":10,"offsetLeft":1511,"localName":"div","namespaceURI":"http://www.w3.org/1999/xhtml","tagName":"DIV","baseURI":"http://localhost:5050/?","nodeType":1,"nodeName":"DIV","attributes":{"class":"alpha","data-test-a":"foo","data-test-b":"bar","style":"margin-top: 10px;"},"childNodes":[{"spellcheck":true,"isContentEditable":false,"contentEditable":"inherit","hidden":false,"draggable":false,"tabIndex":-1,"translate":true,"childElementCount":1,"className":"beta","scrollHeight":178,"scrollWidth":65,"scrollTop":0,"scrollLeft":0,"clientHeight":178,"clientWidth":66,"clientTop":0,"clientLeft":0,"offsetHeight":178,"offsetWidth":66,"offsetTop":13,"offsetLeft":1514,"localName":"div","namespaceURI":"http://www.w3.org/1999/xhtml","tagName":"DIV","baseURI":"http://localhost:5050/?","nodeType":1,"nodeName":"DIV","attributes":{"class":"beta","data-test-c":"quux","data-test-d":"baz","style":"color: red;"},"childNodes":[{"spellcheck":true,"isContentEditable":false,"contentEditable":"inherit","hidden":false,"draggable":false,"tabIndex":-1,"translate":true,"childElementCount":1,"className":"charlie","scrollHeight":176,"scrollWidth":63,"scrollTop":0,"scrollLeft":0,"clientHeight":176,"clientWidth":64,"clientTop":1,"clientLeft":1,"offsetHeight":178,"offsetWidth":66,"offsetTop":13,"offsetLeft":1514,"localName":"div","namespaceURI":"http://www.w3.org/1999/xhtml","tagName":"DIV","baseURI":"http://localhost:5050/?","nodeType":1,"nodeName":"DIV","attributes":{"class":"charlie","data-test-e":"norf","data-test-f":"woop","style":"border: 1px solid green;"},"childNodes":[{"spellcheck":true,"isContentEditable":false,"contentEditable":"inherit","hidden":false,"draggable":false,"tabIndex":-1,"translate":true,"childElementCount":1,"className":"delta","scrollHeight":144,"scrollWidth":63,"scrollTop":0,"scrollLeft":0,"clientHeight":144,"clientWidth":64,"clientTop":0,"clientLeft":0,"offsetHeight":144,"offsetWidth":64,"offsetTop":30,"offsetLeft":1515,"localName":"p","namespaceURI":"http://www.w3.org/1999/xhtml","tagName":"P","baseURI":"http://localhost:5050/?","nodeType":1,"nodeName":"P","attributes":{"class":"delta"},"childNodes":[{"length":25,"data":"This is a test paragraph ","baseURI":"http://localhost:5050/?","nodeType":3,"nodeValue":"This is a test paragraph ","nodeName":"#text","childNodes":[]},{"spellcheck":true,"isContentEditable":false,"contentEditable":"inherit","hidden":false,"draggable":false,"tabIndex":-1,"translate":true,"childElementCount":0,"className":"epsilon","scrollHeight":0,"scrollWidth":0,"scrollTop":0,"scrollLeft":0,"clientHeight":0,"clientWidth":0,"clientTop":0,"clientLeft":0,"offsetHeight":71,"offsetWidth":46,"offsetTop":84,"offsetLeft":1515,"localName":"span","namespaceURI":"http://www.w3.org/1999/xhtml","tagName":"SPAN","baseURI":"http://localhost:5050/?","nodeType":1,"nodeName":"SPAN","attributes":{"class":"epsilon"},"childNodes":[{"length":25,"data":"with a span in the middle","baseURI":"http://localhost:5050/?","nodeType":3,"nodeValue":"with a span in the middle","nodeName":"#text","childNodes":[]}]},{"length":7,"data":" of it.","baseURI":"http://localhost:5050/?","nodeType":3,"nodeValue":" of it.","nodeName":"#text","childNodes":[]}]}]}]},{"length":25,"data":"This is a sample comment!","baseURI":"http://localhost:5050/?","nodeType":8,"nodeValue":"This is a sample comment!","nodeName":"#comment","childNodes":[]},{"target":"xml-stylesheet","length":32,"data":"href=\"mycss.css\" type=\"text/css\"","baseURI":"http://localhost:5050/?","nodeType":7,"nodeValue":"href=\"mycss.css\" type=\"text/css\"","nodeName":"xml-stylesheet","childNodes":[]}]}]}}';
+					stringifiedTest = '{"meta":{"href":"http://localhost:9876/context.html","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36","version":"0.1.2","clock":22,"date":"2018-08-16T16:01:14.506Z","dimensions":{"inner":{"x":1200,"y":628},"outer":{"x":1200,"y":702}},"options":{"absolutePaths":["action","data","href","src"],"attributes":true,"computedStyle":false,"cull":true,"deep":true,"domProperties":[true,"attributes","childNodes","children","classList","dataset","style","innerHTML","innerText","outerHTML","outerText","prefix","text","textContent","wholeText"],"filter":false,"htmlOnly":false,"metadata":true,"serialProperties":false,"stringify":true,"allowDangerousElements":true,"absoluteBase":"http://localhost:9876/"}},"node":{"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":10,"offsetLeft":1200,"offsetWidth":66,"offsetHeight":178,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"div","tagName":"DIV","className":"container otherClass","scrollTop":0,"scrollLeft":0,"scrollWidth":66,"scrollHeight":178,"clientTop":0,"clientLeft":0,"clientWidth":66,"clientHeight":178,"childElementCount":1,"nodeType":1,"nodeName":"DIV","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"class":"container otherClass"},"childNodes":[{"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":10,"offsetLeft":1200,"offsetWidth":66,"offsetHeight":178,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"div","tagName":"DIV","className":"alpha","scrollTop":0,"scrollLeft":0,"scrollWidth":66,"scrollHeight":178,"clientTop":0,"clientLeft":0,"clientWidth":66,"clientHeight":178,"childElementCount":3,"nodeType":1,"nodeName":"DIV","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"class":"alpha","data-test-a":"foo","data-test-b":"bar","style":"margin-top: 10px;"},"childNodes":[{"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":10,"offsetLeft":1200,"offsetWidth":66,"offsetHeight":178,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"div","tagName":"DIV","className":"beta","scrollTop":0,"scrollLeft":0,"scrollWidth":66,"scrollHeight":178,"clientTop":0,"clientLeft":0,"clientWidth":66,"clientHeight":178,"childElementCount":1,"nodeType":1,"nodeName":"DIV","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"class":"beta","data-test-c":"quux","data-test-d":"baz","style":"color: red;"},"childNodes":[{"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":10,"offsetLeft":1200,"offsetWidth":66,"offsetHeight":178,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"div","tagName":"DIV","className":"charlie","scrollTop":0,"scrollLeft":0,"scrollWidth":64,"scrollHeight":176,"clientTop":1,"clientLeft":1,"clientWidth":64,"clientHeight":176,"childElementCount":1,"nodeType":1,"nodeName":"DIV","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"class":"charlie","data-test-e":"norf","data-test-f":"woop","style":"border: 1px solid green;"},"childNodes":[{"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":27,"offsetLeft":1201,"offsetWidth":64,"offsetHeight":144,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"p","tagName":"P","className":"delta","scrollTop":0,"scrollLeft":0,"scrollWidth":64,"scrollHeight":144,"clientTop":0,"clientLeft":0,"clientWidth":64,"clientHeight":144,"childElementCount":1,"nodeType":1,"nodeName":"P","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"class":"delta"},"childNodes":[{"data":"This is a test paragraph ","length":25,"nodeType":3,"nodeName":"#text","baseURI":"http://localhost:9876/context.html","isConnected":true,"nodeValue":"This is a test paragraph ","childNodes":[]},{"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":81,"offsetLeft":1201,"offsetWidth":46,"offsetHeight":72,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"span","tagName":"SPAN","className":"epsilon","scrollTop":0,"scrollLeft":0,"scrollWidth":0,"scrollHeight":0,"clientTop":0,"clientLeft":0,"clientWidth":0,"clientHeight":0,"childElementCount":0,"nodeType":1,"nodeName":"SPAN","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"class":"epsilon"},"childNodes":[{"data":"with a span in the middle","length":25,"nodeType":3,"nodeName":"#text","baseURI":"http://localhost:9876/context.html","isConnected":true,"nodeValue":"with a span in the middle","childNodes":[]}]},{"data":" of it.","length":7,"nodeType":3,"nodeName":"#text","baseURI":"http://localhost:9876/context.html","isConnected":true,"nodeValue":" of it.","childNodes":[]}]}]}]},{"data":"This is a sample comment!","length":25,"nodeType":8,"nodeName":"#comment","baseURI":"http://localhost:9876/context.html","isConnected":true,"nodeValue":"This is a sample comment!","childNodes":[]},{"disabled":false,"href":"http://localhost:9876/style.css","rel":"stylesheet","translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":0,"offsetLeft":0,"offsetWidth":0,"offsetHeight":0,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"link","tagName":"LINK","scrollTop":0,"scrollLeft":0,"scrollWidth":0,"scrollHeight":0,"clientTop":0,"clientLeft":0,"clientWidth":0,"clientHeight":0,"childElementCount":0,"nodeType":1,"nodeName":"LINK","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"href":"http://localhost:9876/style.css","rel":"stylesheet"},"childNodes":[]},{"type":"text/javascript","noModule":false,"async":true,"defer":false,"translate":true,"hidden":false,"tabIndex":-1,"draggable":false,"spellcheck":true,"contentEditable":"inherit","isContentEditable":false,"offsetTop":0,"offsetLeft":0,"offsetWidth":0,"offsetHeight":0,"namespaceURI":"http://www.w3.org/1999/xhtml","localName":"script","tagName":"SCRIPT","scrollTop":0,"scrollLeft":0,"scrollWidth":0,"scrollHeight":0,"clientTop":0,"clientLeft":0,"clientWidth":0,"clientHeight":0,"childElementCount":0,"nodeType":1,"nodeName":"SCRIPT","baseURI":"http://localhost:9876/context.html","isConnected":true,"attributes":{"type":"text/javascript"},"childNodes":[{"data":"// nothing here","length":15,"nodeType":3,"nodeName":"#text","baseURI":"http://localhost:9876/context.html","isConnected":true,"nodeValue":"// nothing here","childNodes":[]}]}]}]}}';
 				}
 			});
 
@@ -1068,6 +1092,24 @@
 				expect($('.testArea .charlie').get(0).style['borderStyle']).toBe('solid');
 				expect($('.testArea .delta').text()).toBe('This is a test paragraph with a span in the middle of it.')
 				expect($('.testArea .epsilon').text()).toBe('with a span in the middle');
+			});
+
+			it('should skip "link" and "script" tags per default', function(){
+				var result = domJSON.toDOM(JSON.parse(stringifiedTest));
+				testArea.append(result);
+
+				expect($('.testArea link').length).toBe(0);
+				expect($('.testArea script').length).toBe(0);
+			});
+
+			it('should not skip "link" and "script" tags with `allowDangerousElements: true` option', function(){
+				var result = domJSON.toDOM(JSON.parse(stringifiedTest), {
+					allowDangerousElements: true
+				});
+				testArea.append(result);
+
+				expect($('.testArea link').length).toBe(1);
+				expect($('.testArea script').length).toBe(1);
 			});
 		});
 	});


### PR DESCRIPTION
* Adds an option `allowDangerousElements` to serialization and deserialization (off per default to maintain behavior). Details are discussed here: https://github.com/azaslavsky/domJSON/issues/28

* Update corresponding test cases

* Update the documentation (needed to update `gulp-jsdoc-to-markdown` dependency, because the current version would throw errors on my system; documentation structure looks slightly different now, which seems to be caused by this update)