### PR TITLE
Updates license header in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,8 @@ If you make changes that you feel need to be documented in the readme, please up
 ```
 gulp docs
 ```
-##License
+
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
The license header in the README was missing spaces after the `##`, so it was not rendering as a header. This commit adds a space, so it will it will render as a markdown header.

Screenshot of diff:

![Screen Shot 2019-03-12 at 5 34 50 PM](https://user-images.githubusercontent.com/691365/54237832-3cd46080-44ed-11e9-9d0c-723d084e67fa.png)
